### PR TITLE
Fix wrong endpoint on HTTP API for user awards

### DIFF
--- a/docs/v1/users/user-awards.md
+++ b/docs/v1/users/user-awards.md
@@ -16,7 +16,7 @@ The easiest place to see a summary of user awards in the Progression Status comp
 
 ## HTTP Request
 
-<SampleRequest httpVerb="GET">https://retroachievements.org/API/API_GetGameInfoAndUserProgress.php?u=MaxMilyin</SampleRequest>
+<SampleRequest httpVerb="GET">https://retroachievements.org/API/API_GetUserAwards.php?u=MaxMilyin</SampleRequest>
 
 ### Query Parameters
 


### PR DESCRIPTION
Seems like the URL is wrong and should be `API_GetUserAwards.php` here *(noticed this while writing my own documentation* :wink: *)* 