### PR TITLE
docs: remove z param references

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,7 @@ Store your API key as though it is a secret, like a password. Avoid checking in 
 
 ## Quick Start (HTTP Requests)
 
-With web API key, you now have all you need to call any endpoint in the API.
+With your web API key, you now have all you need to call any endpoint in the API.
 
 ```bash
 curl https://retroachievements.org/API/API_GetTopTenUsers.php?&y=[your_key]

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,10 +19,10 @@ Store your API key as though it is a secret, like a password. Avoid checking in 
 
 ## Quick Start (HTTP Requests)
 
-With your username and web API key, you now have all you need to call any endpoint in the API.
+With web API key, you now have all you need to call any endpoint in the API.
 
 ```bash
-curl https://retroachievements.org/API/API_GetTopTenUsers.php?z=[your_username]&y=[your_key]
+curl https://retroachievements.org/API/API_GetTopTenUsers.php?&y=[your_key]
 ```
 
 ## Quick Start (Client Library)

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,10 +40,10 @@ If your individual rate limit is not enough for your use case, then please reach
 
 ### Using your key
 
-Provide your username to the `z` query param and your API key to the `y` query param.
+Provide your API key to the `y` query param.
 
 ```
-https://retroachievements.org/API/API_GetAchievementOfTheWeek.php?z=[your_username]&y=[your_key]
+https://retroachievements.org/API/API_GetAchievementOfTheWeek.php?&y=[your_key]
 ```
 
 ## Client Libraries

--- a/docs/v1/get-achievement-count.md
+++ b/docs/v1/get-achievement-count.md
@@ -22,7 +22,6 @@ When browsing a game page, for example, [Sonic the Hedgehog](https://retroachiev
 
 | Name | Required? | Description         |
 | :--- | :-------- | :------------------ |
-| `z`  | Yes       | Your username.      |
 | `y`  | Yes       | Your web API key.   |
 | `i`  | Yes       | The target game ID. |
 

--- a/docs/v1/get-achievement-distribution.md
+++ b/docs/v1/get-achievement-distribution.md
@@ -22,7 +22,6 @@ When browsing a game page, for example, [Sonic the Hedgehog](https://retroachiev
 
 | Name | Required? | Description                                                                |
 | :--- | :-------- | :------------------------------------------------------------------------- |
-| `z`  | Yes       | Your username.                                                             |
 | `y`  | Yes       | Your web API key.                                                          |
 | `i`  | Yes       | The target game ID.                                                        |
 | `h`  |           | 1 to only query hardcore unlocks. 0 to query all unlocks. Defaults to 0.   |

--- a/docs/v1/get-achievement-of-the-week.md
+++ b/docs/v1/get-achievement-of-the-week.md
@@ -22,7 +22,6 @@ The current Achievement of the Week can be found on the site's home page:
 
 | Name | Required? | Description       |
 | :--- | :-------- | :---------------- |
-| `z`  | Yes       | Your username.    |
 | `y`  | Yes       | Your web API key. |
 
 ## Client Library

--- a/docs/v1/get-achievement-unlocks.md
+++ b/docs/v1/get-achievement-unlocks.md
@@ -16,7 +16,6 @@ A call to this endpoint will retrieve a list of users who have earned an achieve
 
 | Name | Required? | Description                                                 |
 | :--- | :-------- | :---------------------------------------------------------- |
-| `z`  | Yes       | Your username.                                              |
 | `y`  | Yes       | Your web API key.                                           |
 | `a`  | Yes       | The target achievement ID.                                  |
 | `c`  |           | Count, number of records to return (default: 50, max: 500). |

--- a/docs/v1/get-achievements-earned-between.md
+++ b/docs/v1/get-achievements-earned-between.md
@@ -22,7 +22,6 @@ A user's unlocks by a date range can be found manually via the user history:
 
 | Name | Required? | Description                        |
 | :--- | :-------- | :--------------------------------- |
-| `z`  | Yes       | Your username.                     |
 | `y`  | Yes       | Your web API key.                  |
 | `u`  | Yes       | The target username.               |
 | `f`  | Yes       | Epoch timestamp. Time range start. |

--- a/docs/v1/get-achievements-earned-on-day.md
+++ b/docs/v1/get-achievements-earned-on-day.md
@@ -22,7 +22,6 @@ A user's unlocks by date can be found via the user history:
 
 | Name | Required? | Description                |
 | :--- | :-------- | :------------------------- |
-| `z`  | Yes       | Your username.             |
 | `y`  | Yes       | Your web API key.          |
 | `u`  | Yes       | The target username.       |
 | `d`  | Yes       | Date in YYYY-MM-DD format. |

--- a/docs/v1/get-active-claims.md
+++ b/docs/v1/get-active-claims.md
@@ -16,7 +16,6 @@ A call to this endpoint returns information about all (1000 max) active set clai
 
 | Name | Required? | Description       |
 | :--- | :-------- | :---------------- |
-| `z`  | Yes       | Your username.    |
 | `y`  | Yes       | Your web API key. |
 
 ## Client Library

--- a/docs/v1/get-claims.md
+++ b/docs/v1/get-claims.md
@@ -16,7 +16,6 @@ A call to this endpoint returns information about all (1000 max) achievement set
 
 | Name | Required? | Description                                                                        |
 | :--- | :-------- | :--------------------------------------------------------------------------------- |
-| `z`  | Yes       | Your username.                                                                     |
 | `y`  | Yes       | Your web API key.                                                                  |
 | `k`  |           | The desired claim kind: 1 (completed), 2 (dropped), or 3 (expired). Defaults to 1. |
 

--- a/docs/v1/get-game.md
+++ b/docs/v1/get-game.md
@@ -22,7 +22,6 @@ Most of this data can be found on the game page, for example, [Sonic the Hedgeho
 
 | Name | Required? | Description         |
 | :--- | :-------- | :------------------ |
-| `z`  | Yes       | Your username.      |
 | `y`  | Yes       | Your web API key.   |
 | `i`  | Yes       | The target game ID. |
 

--- a/docs/v1/get-recent-game-awards.md
+++ b/docs/v1/get-recent-game-awards.md
@@ -22,7 +22,6 @@ This data can be found on the Recent Game Awards page, for example:
 
 | Name | Required? | Description                                                                                                                                                                |
 | :--- | :-------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `z`  | Yes       | Your username.                                                                                                                                                             |
 | `y`  | Yes       | Your web API key.                                                                                                                                                          |
 | `d`  |           | Starting date (YYYY-MM-DD) (default: now).                                                                                                                                 |
 | `o`  |           | Offset, number of entries to skip (default: 0).                                                                                                                            |

--- a/docs/v1/get-ticket-data/get-achievement-ticket-stats.md
+++ b/docs/v1/get-ticket-data/get-achievement-ticket-stats.md
@@ -16,7 +16,6 @@ A call to `API_GetTicketData` in this manner will retrieve ticket stats for an a
 
 | Name | Required? | Description                                          |
 | :--- | :-------- | :--------------------------------------------------- |
-| `z`  | Yes       | Your username.                                       |
 | `y`  | Yes       | Your web API key.                                    |
 | `a`  | Yes       | The target achievement ID to fetch ticket stats for. |
 

--- a/docs/v1/get-ticket-data/get-developer-ticket-stats.md
+++ b/docs/v1/get-ticket-data/get-developer-ticket-stats.md
@@ -16,7 +16,6 @@ A call to `API_GetTicketData` in this manner will retrieve ticket stats for a de
 
 | Name | Required? | Description                      |
 | :--- | :-------- | :------------------------------- |
-| `z`  | Yes       | Your username.                   |
 | `y`  | Yes       | Your web API key.                |
 | `u`  | Yes       | The target developer's username. |
 

--- a/docs/v1/get-ticket-data/get-game-ticket-stats.md
+++ b/docs/v1/get-ticket-data/get-game-ticket-stats.md
@@ -16,7 +16,6 @@ A call to `API_GetTicketData` in this manner will retrieve ticket stats for a ga
 
 | Name | Required? | Description                                                                  |
 | :--- | :-------- | :--------------------------------------------------------------------------- |
-| `z`  | Yes       | Your username.                                                               |
 | `y`  | Yes       | Your web API key.                                                            |
 | `g`  | Yes       | The target game ID.                                                          |
 | `f`  |           | Set to 5 if you want ticket data for unofficial achievements.                |

--- a/docs/v1/get-ticket-data/get-most-recent-tickets.md
+++ b/docs/v1/get-ticket-data/get-most-recent-tickets.md
@@ -16,7 +16,6 @@ A call to `API_GetTicketData` in this manner will retrieve ticket metadata infor
 
 | Name | Required? | Description                                                 |
 | :--- | :-------- | :---------------------------------------------------------- |
-| `z`  | Yes       | Your username.                                              |
 | `y`  | Yes       | Your web API key.                                           |
 | `c`  |           | Count, number of records to return (default: 10, max: 100). |
 | `o`  |           | Offset, number of entries to skip (default: 0).             |

--- a/docs/v1/get-ticket-data/get-most-ticketed-games.md
+++ b/docs/v1/get-ticket-data/get-most-ticketed-games.md
@@ -16,7 +16,6 @@ A call to `API_GetTicketData` in this manner will retrieve the games on the site
 
 | Name | Required? | Description                                                 |
 | :--- | :-------- | :---------------------------------------------------------- |
-| `z`  | Yes       | Your username.                                              |
 | `y`  | Yes       | Your web API key.                                           |
 | `f`  | Yes       | Must be set to 1.                                           |
 | `c`  |           | Count, number of records to return (default: 10, max: 100). |

--- a/docs/v1/get-ticket-data/get-ticket-by-id.md
+++ b/docs/v1/get-ticket-data/get-ticket-by-id.md
@@ -16,7 +16,6 @@ A call to `API_GetTicketData` in this manner will retrieve ticket metadata infor
 
 | Name | Required? | Description           |
 | :--- | :-------- | :-------------------- |
-| `z`  | Yes       | Your username.        |
 | `y`  | Yes       | Your web API key.     |
 | `i`  | Yes       | The target ticket ID. |
 

--- a/docs/v1/get-top-ten-users.md
+++ b/docs/v1/get-top-ten-users.md
@@ -16,7 +16,6 @@ A call to this endpoint will retrieve the current top ten users, ranked by hardc
 
 | Name | Required? | Description       |
 | :--- | :-------- | :---------------- |
-| `z`  | Yes       | Your username.    |
 | `y`  | Yes       | Your web API key. |
 
 ## Client Library

--- a/docs/v1/get-user-awards.md
+++ b/docs/v1/get-user-awards.md
@@ -22,7 +22,6 @@ The easiest place to see a summary of user awards in the Progression Status comp
 
 | Name | Required? | Description          |
 | :--- | :-------- | :------------------- |
-| `z`  | Yes       | Your username.       |
 | `y`  | Yes       | Your web API key.    |
 | `u`  | Yes       | The target username. |
 

--- a/docs/v1/get-user-claims.md
+++ b/docs/v1/get-user-claims.md
@@ -16,7 +16,6 @@ A call to this endpoint will retrieve a list of achievement set claims made over
 
 | Name | Required? | Description          |
 | :--- | :-------- | :------------------- |
-| `z`  | Yes       | Your username.       |
 | `y`  | Yes       | Your web API key.    |
 | `u`  | Yes       | The target username. |
 

--- a/docs/v1/get-user-completed-games.md
+++ b/docs/v1/get-user-completed-games.md
@@ -22,7 +22,6 @@ A call to this endpoint will retrieve completion metadata about the games a give
 
 | Name | Required? | Description          |
 | :--- | :-------- | :------------------- |
-| `z`  | Yes       | Your username.       |
 | `y`  | Yes       | Your web API key.    |
 | `u`  | Yes       | The target username. |
 

--- a/docs/v1/get-user-completion-progress.md
+++ b/docs/v1/get-user-completion-progress.md
@@ -22,7 +22,6 @@ A user's completion progress can be found in several places, most prolifically o
 
 | Name | Required? | Description                                                  |
 | :--- | :-------- | :----------------------------------------------------------- |
-| `z`  | Yes       | Your username.                                               |
 | `y`  | Yes       | Your web API key.                                            |
 | `u`  | Yes       | The target username.                                         |
 | `c`  |           | Count, number of records to return (default: 100, max: 500). |

--- a/docs/v1/get-user-game-rank-and-score.md
+++ b/docs/v1/get-user-game-rank-and-score.md
@@ -16,7 +16,6 @@ A call to this endpoint will retrieve metadata about how a given user has perfor
 
 | Name | Required? | Description          |
 | :--- | :-------- | :------------------- |
-| `z`  | Yes       | Your username.       |
 | `y`  | Yes       | Your web API key.    |
 | `u`  | Yes       | The target username. |
 | `g`  | Yes       | The target game ID.  |

--- a/docs/v1/get-user-points.md
+++ b/docs/v1/get-user-points.md
@@ -16,7 +16,6 @@ A call to this endpoint will retrieve a given user's hardcore and softcore point
 
 | Name | Required? | Description          |
 | :--- | :-------- | :------------------- |
-| `z`  | Yes       | Your username.       |
 | `y`  | Yes       | Your web API key.    |
 | `u`  | Yes       | The target username. |
 

--- a/docs/v1/get-user-profile.md
+++ b/docs/v1/get-user-profile.md
@@ -22,7 +22,6 @@ This information can be found near the top of [any user page](https://retroachie
 
 | Name | Required? | Description          |
 | :--- | :-------- | :------------------- |
-| `z`  | Yes       | Your username.       |
 | `y`  | Yes       | Your web API key.    |
 | `u`  | Yes       | The target username. |
 

--- a/docs/v1/get-user-progress.md
+++ b/docs/v1/get-user-progress.md
@@ -22,7 +22,6 @@ Unless you are explicitly wanting summary progress details for specific game IDs
 
 | Name | Required? | Description                                      |
 | :--- | :-------- | :----------------------------------------------- |
-| `z`  | Yes       | Your username.                                   |
 | `y`  | Yes       | Your web API key.                                |
 | `u`  | Yes       | The target username.                             |
 | `i`  | Yes       | The target game IDs, as a comma-separated value. |

--- a/docs/v1/get-user-recent-achievements.md
+++ b/docs/v1/get-user-recent-achievements.md
@@ -26,7 +26,6 @@ The recent unlocks can also be found on the "Unlocked Achievements" page:
 
 | Name | Required? | Description                           |
 | :--- | :-------- | :------------------------------------ |
-| `z`  | Yes       | Your username.                        |
 | `y`  | Yes       | Your web API key.                     |
 | `u`  | Yes       | The target username.                  |
 | `m`  |           | Minutes to look back. Defaults to 60. |

--- a/docs/v1/get-user-recently-played-games.md
+++ b/docs/v1/get-user-recently-played-games.md
@@ -16,7 +16,6 @@ A call to this endpoint will retrieve a list of a target user's recently played 
 
 | Name | Required? | Description                                                |
 | :--- | :-------- | :--------------------------------------------------------- |
-| `z`  | Yes       | Your username.                                             |
 | `y`  | Yes       | Your web API key.                                          |
 | `u`  | Yes       | The target username.                                       |
 | `c`  |           | Count, number of records to return (default: 10, max: 50). |

--- a/docs/v1/get-user-summary.md
+++ b/docs/v1/get-user-summary.md
@@ -22,7 +22,6 @@ This endpoint is known to be slow, and often results in over-fetching. For basic
 
 | Name | Required? | Description                                               |
 | :--- | :-------- | :-------------------------------------------------------- |
-| `z`  | Yes       | Your username.                                            |
 | `y`  | Yes       | Your web API key.                                         |
 | `u`  | Yes       | The target username.                                      |
 | `g`  |           | The number of recent games to return (default: 0).        |


### PR DESCRIPTION
This is the accompanying docs PR for https://github.com/RetroAchievements/RAWeb/pull/2591#pullrequestreview-2221037120

Worth noting, the Kotlin and NodeJS sections still include building an authorization with username. This is okay and will not break anything, but these two libraries should be updated to remove it as a requirement. Once that is done, the docs will need to be updated to remove it as well. 