### PR TITLE
docs: fix get user profile http response

### DIFF
--- a/docs/v1/get-user-profile.md
+++ b/docs/v1/get-user-profile.md
@@ -87,7 +87,7 @@ if (response is NetworkResponse.Success) {
   "Permissions": 1,
   "Untracked": 0,
   "ID": 16446,
-  "UserWallActive": 1,
+  "UserWallActive": true,
   "Motto": "Join me on Twitch! GameSquadSquad for live RA"
 }
 ```


### PR DESCRIPTION
While testing some of the API i noticed the response on this endpoint is incorrect for the UserWallActive, using a boolean instead of a number. This is just a correction

Actual response:
![Screenshot from 2024-08-11 11-00-21](https://github.com/user-attachments/assets/48c54ba2-6f85-4048-bb29-720d2da33227)
