### PR TITLE
docs: fix GetUserWantToPlayList, GetGameRankAndScore, GetLeaderboardEntries, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Click the function names to open their complete docs on the docs site.
 - [Unlocks Distribution](https://api-docs.retroachievements.org/v1/get-achievement-distribution.html) - Get how many players have unlocked how many achievements for a game.
 - [High Scores](https://api-docs.retroachievements.org/v1/get-game-rank-and-score.html) - Get a list of either the latest masters or highest hardcore points earners for a game.
 
+### Leaderboards
+
+- [Leaderboards (by gameID)](https://api-docs.retroachievements.org/v1/get-game-leaderboards.html) - Get a given games's list of leaderboards.
+- [Entries](https://api-docs.retroachievements.org/v1/get-leaderboard-entries.html) - Get a given leadboard's entires.
+
 ### System
 
 - [Get All Systems](https://api-docs.retroachievements.org/v1/get-console-ids.html) - Get the complete list of system ID and name pairs on the site.

--- a/docs/v1/get-game-rank-and-score.md
+++ b/docs/v1/get-game-rank-and-score.md
@@ -22,9 +22,8 @@ When browsing a game page, for example, [Sonic the Hedgehog](https://retroachiev
 
 | Name | Required? | Description                                                        |
 | :--- | :-------- | :----------------------------------------------------------------- |
-| `z`  | Yes       | Your username.                                                     |
 | `y`  | Yes       | Your web API key.                                                  |
-| `i`  | Yes       | The target game ID.                                                |
+| `g`  | Yes       | The target game ID.                                                |
 | `t`  |           | 1 for latest masters. 0 for non-master high scores. Defaults to 0. |
 
 ## Client Library

--- a/docs/v1/get-leaderboard-entries.md
+++ b/docs/v1/get-leaderboard-entries.md
@@ -22,7 +22,6 @@ A leaderboards's entries can be found on the leaderboard info page:
 
 | Name | Required? | Description                                                  |
 | :--- | :-------- | :----------------------------------------------------------- |
-| `z`  | Yes       | Your username.                                               |
 | `y`  | Yes       | Your web API key.                                            |
 | `i`  | Yes       | The target leaderboard ID.                                   |
 | `c`  |           | Count, number of records to return (default: 100, max: 500). |
@@ -46,7 +45,7 @@ Not yet supported.
       "User": "vani11a",
       "Score": 390490,
       "FormattedScore": "390,490",
-      "DateSubmitted": "2024-07-25T15:51:00Z"
+      "DateSubmitted": "2024-07-25T15:51:00+00:00"
     }
     // ...
   ]

--- a/docs/v1/get-user-want-to-play-list.md
+++ b/docs/v1/get-user-want-to-play-list.md
@@ -22,7 +22,6 @@ The user's Want to Play Games list page looks like:
 
 | Name | Required? | Description                                                  |
 | :--- | :-------- | :----------------------------------------------------------- |
-| `z`  | Yes       | Your username.                                               |
 | `y`  | Yes       | Your web API key.                                            |
 | `u`  | Yes       | The target username.                                         |
 | `c`  |           | Count, number of records to return (default: 100, max: 500). |
@@ -42,7 +41,7 @@ Not yet supported.
   "Total": 1287,
   "Results": [
     {
-      "GameID": 20246,
+      "ID": 20246,
       "Title": "~Hack~ Knuckles the Echidna in Sonic the Hedgehog",
       "ImageIcon": "/Images/074560.png",
       "ConsoleID": 1,


### PR DESCRIPTION
I noticed the `ID` field on the GetUserWantToPlayList is marked as `GameID`, but the actual response only has ID. Also I don't think we need the `z` parameter anymore, but maybe you can tell me if i'm wrong

Edit: I'm also seeing a mismatching in the GetGameRankAndScore query parameters. I removed the `z` parameter and change the `i` to a `g` in accordance with what the request expects based on the [php code](https://github.com/RetroAchievements/RAWeb/blob/master/public/API/API_GetGameRankAndScore.php#L5)

Added missing `Leaderboards` endpoints to the readme

![Screenshot from 2024-11-18 22-59-14](https://github.com/user-attachments/assets/1a4bf140-40a6-4621-81f6-50bcca1d12aa)

GetLeaderboardEntries response gives back the `+00:00` timezone instead of `Z`

![Screenshot from 2024-11-22 07-13-48](https://github.com/user-attachments/assets/33e6c096-a34e-463a-b91b-3c61ba851ecb)

