### PR TITLE
Update get-user-profile.md and get-developer-ticket-stats.md

### DIFF
--- a/docs/v1/get-ticket-data/get-developer-ticket-stats.md
+++ b/docs/v1/get-ticket-data/get-developer-ticket-stats.md
@@ -16,11 +16,10 @@ A call to `API_GetTicketData` in this manner will retrieve ticket stats for a de
 
 You must query the developer by either their username or their ULID. Please note the username is not considered a stable value. As of 2025, users can change their usernames. Initially querying by username is a good way to fetch a ULID.
 
-| Name | Required? | Description                      |
-| :--- | :-------- | :------------------------------- |
-| `y`  | Yes       | Your web API key.                |
-| `u`  |           | The target developer's username. |
-| `i`  |           | The target developer's ULID.     |
+| Name | Required? | Description                              |
+| :--- | :-------- | :--------------------------------------- |
+| `y`  | Yes       | Your web API key.                        |
+| `u`  |           | The target developer's username or ULID. |
 
 ## Client Library
 

--- a/docs/v1/get-user-profile.md
+++ b/docs/v1/get-user-profile.md
@@ -22,11 +22,10 @@ This information can be found near the top of [any user page](https://retroachie
 
 You must query the user by either their username or their ULID. Please note the username is not considered a stable value. As of 2025, users can change their usernames. Initially querying by username is a good way to fetch a ULID.
 
-| Name | Required? | Description             |
-| :--- | :-------- | :---------------------- |
-| `y`  | Yes       | Your web API key.       |
-| `u`  |           | The target username.    |
-| `i`  |           | The target user's ULID. |
+| Name | Required? | Description                  |
+| :--- | :-------- | :----------------------------|
+| `y`  | Yes       | Your web API key.            |
+| `u`  | Yes       | The target username or ULID. |
 
 ## Client Library
 


### PR DESCRIPTION
Removes the mention of the "i" on both pages query parameter for the ULID as it needs to be inputted into the "u" query parameter.